### PR TITLE
Removing print from feat07

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -67,18 +67,3 @@ script.on_init(function()
     global.tick_schedule = {}   --value={ticks=number, handler=function}
     global.depleted_chunks = {}  --key=position.x, value={position.y=bool}
 end)
-
-local function on_trigger_created_entity(event)
-    local surface = event.entity.surface
-    local position = event.entity.position
-
-    if string.match(event.entity.name, "meteor[-]%d%d")
-    and surface.map_gen_settings.autoplace_controls["se-vitamelange"].frequency > 0
-    then
-        game.print("biter meteor: " .. event.entity.name)
-    end
-    game.print(event.entity.name)
-end
-
-script.on_event(defines.events.on_trigger_created_entity, on_trigger_created_entity)
-


### PR DESCRIPTION
It is a little hard to tell from the change itself, but I suspect this was added while debugging and missed before merge. It did occur to me you might want to message out during that particular event but when tested I saw a `biter meteor: se-trigger-movable-meteor-13-debris` so figured it might not be flushed out.

I am opening this PR because it actually results in events from multiple mod-packs printing to the screen (line 80). No functional issues but every time I anyone uses the grappling-gun everyone on the server is notified 😄.